### PR TITLE
New marker: misc – are syntax error in 00

### DIFF
--- a/communitymap.json
+++ b/communitymap.json
@@ -3690,6 +3690,24 @@
       "userEdited": false,
       "wasCommunityKept": false,
       "isCommunity": true
+    },
+    {
+      "id": "id-1d9fe31b-6b29-45d6-8170-8a00b159223e",
+      "cid": "misc_are_syntax_error_in_00_list_in_102_grid_a5_x_402_y_1750_submitted_by_caliber_280_1750_402",
+      "category": "misc",
+      "desc": "are syntax error in 00\nlist in 102\nGrid A5 (X: 402, Y: 1750)\nSubmitted By Caliber 280",
+      "lat": 1750.333251953125,
+      "lng": 402.0784648187632,
+      "icon": "Notepad",
+      "addedTime": 1764979902461,
+      "locked": true,
+      "isPostcard": false,
+      "isTemp": false,
+      "startTime": null,
+      "keepBtnBound": false,
+      "userEdited": false,
+      "wasCommunityKept": false,
+      "isCommunity": true
     }
   ]
 }


### PR DESCRIPTION
**Submitted by:** Caliber 280

**Preview:** 📝 misc

**Full marker (stored safely):**
```json
{
  "id": "id-1d9fe31b-6b29-45d6-8170-8a00b159223e",
  "cid": "misc_are_syntax_error_in_00_list_in_102_grid_a5_x_402_y_1750_submitted_by_caliber_280_1750_402",
  "category": "misc",
  "desc": "are syntax error in 00\nlist in 102\nGrid A5 (X: 402, Y: 1750)\nSubmitted By Caliber 280",
  "lat": 1750.333251953125,
  "lng": 402.0784648187632,
  "icon": "Notepad",
  "addedTime": 1764979902461,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```

_via Fallout 76 Item Finder v76.7.6+_