### PR TITLE
New marker: train stations – train station yup a train station.

### DIFF
--- a/communitymap.json
+++ b/communitymap.json
@@ -3708,6 +3708,24 @@
       "userEdited": false,
       "wasCommunityKept": false,
       "isCommunity": true
+    },
+    {
+      "id": "id-d47d01d8-9971-43b2-907c-be8deef16d67",
+      "cid": "train stations_train_station_yup_a_train_station_grid_a7_x_242_y_2604_submitted_by_mrcrazy_2604_242",
+      "category": "train stations",
+      "desc": "train station yup a train station.\nGrid A7 (X: 242, Y: 2604)\nSubmitted By MrCrazy",
+      "lat": 2604.1407992671384,
+      "lng": 242.49564572478025,
+      "icon": "🚂",
+      "addedTime": 1765090424198,
+      "locked": true,
+      "isPostcard": false,
+      "isTemp": false,
+      "startTime": null,
+      "keepBtnBound": false,
+      "userEdited": false,
+      "wasCommunityKept": false,
+      "isCommunity": true
     }
   ]
 }


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Preview:** 🚂 train stations

**Full marker:**
```json
{
  "id": "id-d47d01d8-9971-43b2-907c-be8deef16d67",
  "cid": "train stations_train_station_yup_a_train_station_grid_a7_x_242_y_2604_submitted_by_mrcrazy_2604_242",
  "category": "train stations",
  "desc": "train station yup a train station.\nGrid A7 (X: 242, Y: 2604)\nSubmitted By MrCrazy",
  "lat": 2604.1407992671384,
  "lng": 242.49564572478025,
  "icon": "🚂",
  "addedTime": 1765090424198,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```

_via Fallout 76 Item Finder v76.7.6_+