### PR TITLE
New marker: treasure maps – the mire treasure map #4 dig site To find this treasure, you have to go to the bridge near crevasse dam. west of the bridge, down the riverbank, do not go down under the bridge. you will find the mound with the treasure closer to the top of river bank between water and bridge.

### DIFF
--- a/communitymap.json
+++ b/communitymap.json
@@ -3762,6 +3762,24 @@
       "userEdited": false,
       "wasCommunityKept": false,
       "isCommunity": true
+    },
+    {
+      "id": "id-ba098d8e-1ef3-493b-9fc1-a16c5349db28",
+      "cid": "treasure maps_the_mire_treasure_map_4_dig_site_to_find_this_treasure_you_have_to_go_to_the_bridge_near_crevasse_dam_west_of_the_bridge_down_the_riverbank_do_not_go_down_under_the_bridge_you_will_find_the_mound_with_the_treasure_closer_to_the_top_of_river_bank_between_water_and_bridge_grid_i7_x_3332_y_2782_submitted_by_mrcrazy_2782_3332",
+      "category": "treasure maps",
+      "desc": "the mire treasure map #4 dig site To find this treasure, you have to go to the bridge near crevasse dam. west of the bridge, down the riverbank, do not go down under the bridge. you will find the mound with the treasure closer to the top of river bank between water and bridge.\nGrid I7 (X: 3332, Y: 2782)\nSubmitted By MrCrazy",
+      "lat": 2781.786478967577,
+      "lng": 3331.806199280821,
+      "icon": "🗺️",
+      "addedTime": 1765099155291,
+      "locked": true,
+      "isPostcard": false,
+      "isTemp": false,
+      "startTime": null,
+      "keepBtnBound": false,
+      "userEdited": false,
+      "wasCommunityKept": false,
+      "isCommunity": true
     }
   ]
 }


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Preview:** 🗺️ treasure maps

**Full marker:**
```json
{
  "id": "id-ba098d8e-1ef3-493b-9fc1-a16c5349db28",
  "cid": "treasure maps_the_mire_treasure_map_4_dig_site_to_find_this_treasure_you_have_to_go_to_the_bridge_near_crevasse_dam_west_of_the_bridge_down_the_riverbank_do_not_go_down_under_the_bridge_you_will_find_the_mound_with_the_treasure_closer_to_the_top_of_river_bank_between_water_and_bridge_grid_i7_x_3332_y_2782_submitted_by_mrcrazy_2782_3332",
  "category": "treasure maps",
  "desc": "the mire treasure map #4 dig site To find this treasure, you have to go to the bridge near crevasse dam. west of the bridge, down the riverbank, do not go down under the bridge. you will find the mound with the treasure closer to the top of river bank between water and bridge.\nGrid I7 (X: 3332, Y: 2782)\nSubmitted By MrCrazy",
  "lat": 2781.786478967577,
  "lng": 3331.806199280821,
  "icon": "🗺️",
  "addedTime": 1765099155291,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```

_via Fallout 76 Item Finder v76.7.6_+