### PR TITLE
New marker: misc – Grid A9 (X: 329, Y: 3282)

### DIFF
--- a/communitymap.json
+++ b/communitymap.json
@@ -3870,6 +3870,24 @@
       "userEdited": false,
       "wasCommunityKept": false,
       "isCommunity": true
+    },
+    {
+      "id": "id-ff8f5ac9-29d4-471c-9639-e9de10484c47",
+      "cid": "misc_grid_a9_x_329_y_3282_submitted_by_mrcrazy_3282_329",
+      "category": "misc",
+      "desc": "Grid A9 (X: 329, Y: 3282)\nSubmitted By MrCrazy",
+      "lat": 3282.1933089046174,
+      "lng": 328.7044813235899,
+      "icon": "📝",
+      "addedTime": 1765121786342,
+      "locked": true,
+      "isPostcard": false,
+      "isTemp": false,
+      "startTime": null,
+      "keepBtnBound": false,
+      "userEdited": false,
+      "wasCommunityKept": false,
+      "isCommunity": true
     }
   ]
 }


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Preview:** 📝 misc

**Full marker:**
```json
{
  "id": "id-ff8f5ac9-29d4-471c-9639-e9de10484c47",
  "cid": "misc_grid_a9_x_329_y_3282_submitted_by_mrcrazy_3282_329",
  "category": "misc",
  "desc": "Grid A9 (X: 329, Y: 3282)\nSubmitted By MrCrazy",
  "lat": 3282.1933089046174,
  "lng": 328.7044813235899,
  "icon": "📝",
  "addedTime": 1765121786342,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```

_via Fallout 76 Item Finder v76.7.6_+