### PR TITLE
New marker: armor – Grid A8 (X: 354, Y: 3262)

### DIFF
--- a/communitymap.json
+++ b/communitymap.json
@@ -3870,6 +3870,23 @@
       "userEdited": false,
       "wasCommunityKept": false,
       "isCommunity": true
+    },
+    {
+      "id": "id-a8337ef6-ace1-4802-8b94-1b8a9592f579",
+      "category": "armor",
+      "desc": "Grid A8 (X: 354, Y: 3262)\nSubmitted By MrCrazy",
+      "lat": 3261.829594776446,
+      "lng": 354.1259514401228,
+      "icon": "🛡️",
+      "addedTime": 1765124199826,
+      "locked": true,
+      "isPostcard": false,
+      "isTemp": false,
+      "startTime": null,
+      "keepBtnBound": false,
+      "userEdited": false,
+      "wasCommunityKept": false,
+      "isCommunity": true
     }
   ]
 }


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Preview:** 🛡️ armor

**Full marker:**
```json
{
  "id": "id-a8337ef6-ace1-4802-8b94-1b8a9592f579",
  "category": "armor",
  "desc": "Grid A8 (X: 354, Y: 3262)\nSubmitted By MrCrazy",
  "lat": 3261.829594776446,
  "lng": 354.1259514401228,
  "icon": "🛡️",
  "addedTime": 1765124199826,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```

_via Fallout 76 Item Finder v76.7.6_+