### PR TITLE
New marker: armor – Grid A8 (X: 354, Y: 3262)

### DIFF
--- a/communitymap.json
+++ b/communitymap.json
@@ -3870,6 +3870,23 @@
       "userEdited": false,
       "wasCommunityKept": false,
       "isCommunity": true
+    },
+    {
+      "id": "id-235a16b9-cb93-4c37-89a5-e3a376cc4b7e",
+      "category": "armor",
+      "desc": "Grid A8 (X: 354, Y: 3262)\nSubmitted By MrCrazy",
+      "lat": 3261.829594776446,
+      "lng": 354.1259514401228,
+      "icon": "🛡️",
+      "addedTime": 1765124208013,
+      "locked": true,
+      "isPostcard": false,
+      "isTemp": false,
+      "startTime": null,
+      "keepBtnBound": false,
+      "userEdited": false,
+      "wasCommunityKept": false,
+      "isCommunity": true
     }
   ]
 }


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Preview:** 🛡️ armor

**Full marker:**
```json
{
  "id": "id-235a16b9-cb93-4c37-89a5-e3a376cc4b7e",
  "category": "armor",
  "desc": "Grid A8 (X: 354, Y: 3262)\nSubmitted By MrCrazy",
  "lat": 3261.829594776446,
  "lng": 354.1259514401228,
  "icon": "🛡️",
  "addedTime": 1765124208013,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```

_via Fallout 76 Item Finder v76.7.6_+