### PR TITLE
New marker: creatures – Grid A9 (X: 333, Y: 3310)

### DIFF
--- a/communitymap.json
+++ b/communitymap.json
@@ -3870,6 +3870,24 @@
       "userEdited": false,
       "wasCommunityKept": false,
       "isCommunity": true
+    },
+    {
+      "id": "id-299d467a-bd7c-4497-9fc5-2446d3aa3777",
+      "cid": "creatures_grid_b8_x_453_y_3198_3198_453",
+      "category": "creatures",
+      "desc": "Grid A9 (X: 333, Y: 3310)\nSubmitted By MrCrazy",
+      "lat": 3310.1095336236895,
+      "lng": 332.75,
+      "icon": "🐺",
+      "addedTime": 1765125268406,
+      "locked": true,
+      "isPostcard": false,
+      "isTemp": false,
+      "startTime": null,
+      "keepBtnBound": false,
+      "userEdited": false,
+      "wasCommunityKept": false,
+      "isCommunity": true
     }
   ]
 }


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Preview:** 🐺 creatures

**Full marker:**
```json
{
  "id": "id-299d467a-bd7c-4497-9fc5-2446d3aa3777",
  "cid": "creatures_grid_b8_x_453_y_3198_3198_453",
  "category": "creatures",
  "desc": "Grid A9 (X: 333, Y: 3310)\nSubmitted By MrCrazy",
  "lat": 3310.1095336236895,
  "lng": 332.75,
  "icon": "🐺",
  "addedTime": 1765125268406,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```

_via Fallout 76 Item Finder v76.7.6_+