### PR TITLE
New marker: creatures – Grid A9 (X: 333, Y: 3310)

### DIFF
--- a/communitymap.json
+++ b/communitymap.json
@@ -3870,6 +3870,24 @@
       "userEdited": false,
       "wasCommunityKept": false,
       "isCommunity": true
+    },
+    {
+      "id": "id-44cd1e1e-e81e-49a4-8cf9-24cfc6f136cd",
+      "cid": "creatures_grid_b8_x_453_y_3198_3198_453",
+      "category": "creatures",
+      "desc": "Grid A9 (X: 333, Y: 3310)\nSubmitted By MrCrazy",
+      "lat": 3310.1095336236895,
+      "lng": 332.75,
+      "icon": "🐺",
+      "addedTime": 1765128476161,
+      "locked": true,
+      "isPostcard": false,
+      "isTemp": false,
+      "startTime": null,
+      "keepBtnBound": false,
+      "userEdited": false,
+      "wasCommunityKept": false,
+      "isCommunity": true
     }
   ]
 }


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Preview:** 🐺 creatures

**Full marker:**
```json
{
  "id": "id-44cd1e1e-e81e-49a4-8cf9-24cfc6f136cd",
  "cid": "creatures_grid_b8_x_453_y_3198_3198_453",
  "category": "creatures",
  "desc": "Grid A9 (X: 333, Y: 3310)\nSubmitted By MrCrazy",
  "lat": 3310.1095336236895,
  "lng": 332.75,
  "icon": "🐺",
  "addedTime": 1765128476161,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```

_via Fallout 76 Item Finder v76.7.7_+