### PR TITLE
New marker: misc – Grid A9 (X: 328, Y: 3340)

### DIFF
--- a/communitymap.json
+++ b/communitymap.json
@@ -3888,6 +3888,24 @@
       "userEdited": false,
       "wasCommunityKept": false,
       "isCommunity": true
+    },
+    {
+      "id": "id-68cc7ffc-6517-405e-abec-df1f4ca3f003",
+      "cid": "misc_grid_a9_x_328_y_3340_3340_328",
+      "category": "misc",
+      "desc": "Grid A9 (X: 328, Y: 3340)\nSubmitted By MrCrazy",
+      "lat": 3340.315731233898,
+      "lng": 328.305398371066,
+      "icon": "📝",
+      "addedTime": 1765130233202,
+      "locked": true,
+      "isPostcard": false,
+      "isTemp": false,
+      "startTime": null,
+      "keepBtnBound": false,
+      "userEdited": false,
+      "wasCommunityKept": false,
+      "isCommunity": true
     }
   ]
 }


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Preview:** 📝 misc

**Full marker:**
```json
{
  "id": "id-68cc7ffc-6517-405e-abec-df1f4ca3f003",
  "cid": "misc_grid_a9_x_328_y_3340_3340_328",
  "category": "misc",
  "desc": "Grid A9 (X: 328, Y: 3340)\nSubmitted By MrCrazy",
  "lat": 3340.315731233898,
  "lng": 328.305398371066,
  "icon": "📝",
  "addedTime": 1765130233202,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```

_via Fallout 76 Item Finder v76.7.6_+