### PR TITLE
New marker: treasure maps – forest treasure map #7 dig site look for the big billboard looking from the back its directly right is the mound at the bottom of the billboard.

### DIFF
--- a/communitymap.json
+++ b/communitymap.json
@@ -4014,6 +4014,24 @@
       "userEdited": false,
       "wasCommunityKept": false,
       "isCommunity": true
+    },
+    {
+      "id": "id-7126ef2f-6785-4734-81d9-935a3dde37e9",
+      "cid": "treasure maps_forest_treasure_map_6_dig_site_look_behide_the_wayward_on_the_rivers_edge_is_the_mound_grid_d6_x_1473_y_2390_2390_1473",
+      "category": "treasure maps",
+      "desc": "forest treasure map #7 dig site look for the big billboard looking from the back its directly right is the mound at the bottom of the billboard.\nGrid D4 (X: 1501, Y: 1455)\nSubmitted By MrCrazy",
+      "lat": 1454.760631253349,
+      "lng": 1500.6369970764024,
+      "icon": "🗺️",
+      "addedTime": 1765582843817,
+      "locked": true,
+      "isPostcard": false,
+      "isTemp": false,
+      "startTime": null,
+      "keepBtnBound": false,
+      "userEdited": false,
+      "wasCommunityKept": false,
+      "isCommunity": true
     }
   ]
 }


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Preview:** 🗺️ treasure maps

**Full marker:**
```json
{
  "id": "id-7126ef2f-6785-4734-81d9-935a3dde37e9",
  "cid": "treasure maps_forest_treasure_map_6_dig_site_look_behide_the_wayward_on_the_rivers_edge_is_the_mound_grid_d6_x_1473_y_2390_2390_1473",
  "category": "treasure maps",
  "desc": "forest treasure map #7 dig site look for the big billboard looking from the back its directly right is the mound at the bottom of the billboard.\nGrid D4 (X: 1501, Y: 1455)\nSubmitted By MrCrazy",
  "lat": 1454.760631253349,
  "lng": 1500.6369970764024,
  "icon": "🗺️",
  "addedTime": 1765582843817,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```

_via Fallout 76 Item Finder v76.READY_+