### PR TITLE
New marker: creatures – yaoguai found here.

### DIFF
--- a/communitymap.json
+++ b/communitymap.json
@@ -4086,6 +4086,24 @@
       "userEdited": false,
       "wasCommunityKept": false,
       "isCommunity": true
+    },
+    {
+      "id": "id-f1f72990-89ec-4caf-a835-645dfed95168",
+      "cid": "creatures_yaoguai_found_here_grid_f7_x_2346_y_2782_2782_2346",
+      "category": "creatures",
+      "desc": "yaoguai found here.\nGrid E4 (X: 1913, Y: 1486)\nSubmitted By MrCrazy",
+      "lat": 1485.965706886826,
+      "lng": 1912.6236657415839,
+      "icon": "🐺",
+      "addedTime": 1765946916957,
+      "locked": true,
+      "isPostcard": false,
+      "isTemp": false,
+      "startTime": null,
+      "keepBtnBound": false,
+      "userEdited": false,
+      "wasCommunityKept": false,
+      "isCommunity": true
     }
   ]
 }


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Preview:** 🐺 creatures

**Full marker:**
```json
{
  "id": "id-f1f72990-89ec-4caf-a835-645dfed95168",
  "cid": "creatures_yaoguai_found_here_grid_f7_x_2346_y_2782_2782_2346",
  "category": "creatures",
  "desc": "yaoguai found here.\nGrid E4 (X: 1913, Y: 1486)\nSubmitted By MrCrazy",
  "lat": 1485.965706886826,
  "lng": 1912.6236657415839,
  "icon": "🐺",
  "addedTime": 1765946916957,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```

_via Fallout 76 Item Finder v76.READY_+