### PR TITLE
New marker: treasure maps – Forest Treasure Map #8 dig site: You will find this treasure southeast of Vault 76 near the point where the railway line crosses the river. This bridge can be seen on the treasure map – if you stand on the bridge and look to the southeast, that is exactly the point of view. The mound of treasure can be found on the south side of the river.

### DIFF
--- a/community-markers/marker-treasure maps_forest_treasure_map_8_dig_site_you_will_find_this_treasure_southeast_of_vault_76_near_the_point_where_the_railway_line_crosses_the_river_this_bridge_can_be_seen_on_the_treasure_map_if_you_stand_on_the_bridge_and_look_to_the_southeast_that_is_exactly_the_point_of_view_the_mound_of_treasure_can_be_found_on_the_south_side_of_the_river_grid_e7_x_17605_y_25624_2562.41786_1760.45231.json
+++ b/community-markers/marker-treasure maps_forest_treasure_map_8_dig_site_you_will_find_this_treasure_southeast_of_vault_76_near_the_point_where_the_railway_line_crosses_the_river_this_bridge_can_be_seen_on_the_treasure_map_if_you_stand_on_the_bridge_and_look_to_the_southeast_that_is_exactly_the_point_of_view_the_mound_of_treasure_can_be_found_on_the_south_side_of_the_river_grid_e7_x_17605_y_25624_2562.41786_1760.45231.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-335f592f-232d-4667-9be1-20027b6aa14d",
+  "cid": "treasure maps_forest_treasure_map_8_dig_site_you_will_find_this_treasure_southeast_of_vault_76_near_the_point_where_the_railway_line_crosses_the_river_this_bridge_can_be_seen_on_the_treasure_map_if_you_stand_on_the_bridge_and_look_to_the_southeast_that_is_exactly_the_point_of_view_the_mound_of_treasure_can_be_found_on_the_south_side_of_the_river_grid_e7_x_17605_y_25624_2562.41786_1760.45231",
+  "category": "treasure maps",
+  "desc": "Forest Treasure Map #8 dig site: You will find this treasure southeast of Vault 76 near the point where the railway line crosses the river. This bridge can be seen on the treasure map – if you stand on the bridge and look to the southeast, that is exactly the point of view. The mound of treasure can be found on the south side of the river.\nGrid E7 (X: 1760.5, Y: 2562.4)\nSubmitted By MrCrazy",
+  "lat": 2562.417857170105,
+  "lng": 1760.4523064702687,
+  "icon": "🗺️",
+  "addedTime": 1776065569767,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-335f592f-232d-4667-9be1-20027b6aa14d",
  "cid": "treasure maps_forest_treasure_map_8_dig_site_you_will_find_this_treasure_southeast_of_vault_76_near_the_point_where_the_railway_line_crosses_the_river_this_bridge_can_be_seen_on_the_treasure_map_if_you_stand_on_the_bridge_and_look_to_the_southeast_that_is_exactly_the_point_of_view_the_mound_of_treasure_can_be_found_on_the_south_side_of_the_river_grid_e7_x_17605_y_25624_2562.41786_1760.45231",
  "category": "treasure maps",
  "desc": "Forest Treasure Map #8 dig site: You will find this treasure southeast of Vault 76 near the point where the railway line crosses the river. This bridge can be seen on the treasure map – if you stand on the bridge and look to the southeast, that is exactly the point of view. The mound of treasure can be found on the south side of the river.\nGrid E7 (X: 1760.5, Y: 2562.4)\nSubmitted By MrCrazy",
  "lat": 2562.417857170105,
  "lng": 1760.4523064702687,
  "icon": "🗺️",
  "addedTime": 1776065569767,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```