### PR TITLE
New marker: treasure maps – Forest Treasure Map #10 dig site: This treasure can be found near Gregg’s Mine Supply, southeast of Vault 76. If you enter the city from the south, stop and turn right towards the river. Look down the river as it goes narrow on the rocks just above the river sits a yellow pickup truck above on the street. You see the mound with treasure on a ledge in the river.

### DIFF
--- a/community-markers/marker-id-e764a830-5b81-4d7c-ad08-2e2b662b81f8.json
+++ b/community-markers/marker-id-e764a830-5b81-4d7c-ad08-2e2b662b81f8.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-e764a830-5b81-4d7c-ad08-2e2b662b81f8",
+  "cid": "treasure maps_forest_treasure_map_10_dig_site_this_treasure_can_be_found_near_greggs_mine_supply_southeast_of_vault_76_if_you_enter_the_city_from_the_south_stop_and_turn_right_towards_the_river_look_down_the_river_as_it_goes_narrow_on_the_rocks_just_above_the_river_sits_a_yellow_pickup_truck_above_on_the_street_you_see_the_mound_with_treasure_on_a_ledge_in_the_river_grid_e6_x_18735_y_2344_2343.97946_1873.51954",
+  "category": "treasure maps",
+  "desc": "Forest Treasure Map #10 dig site: This treasure can be found near Gregg’s Mine Supply, southeast of Vault 76. If you enter the city from the south, stop and turn right towards the river. Look down the river as it goes narrow on the rocks just above the river sits a yellow pickup truck above on the street. You see the mound with treasure on a ledge in the river.\nGrid E6 (X: 1873.3, Y: 2344.2)\nSubmitted By MrCrazy",
+  "lat": 2344.2294642925262,
+  "lng": 1873.3019434671655,
+  "icon": "🗺️",
+  "addedTime": 1776068207650,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-e764a830-5b81-4d7c-ad08-2e2b662b81f8",
  "cid": "treasure maps_forest_treasure_map_10_dig_site_this_treasure_can_be_found_near_greggs_mine_supply_southeast_of_vault_76_if_you_enter_the_city_from_the_south_stop_and_turn_right_towards_the_river_look_down_the_river_as_it_goes_narrow_on_the_rocks_just_above_the_river_sits_a_yellow_pickup_truck_above_on_the_street_you_see_the_mound_with_treasure_on_a_ledge_in_the_river_grid_e6_x_18735_y_2344_2343.97946_1873.51954",
  "category": "treasure maps",
  "desc": "Forest Treasure Map #10 dig site: This treasure can be found near Gregg’s Mine Supply, southeast of Vault 76. If you enter the city from the south, stop and turn right towards the river. Look down the river as it goes narrow on the rocks just above the river sits a yellow pickup truck above on the street. You see the mound with treasure on a ledge in the river.\nGrid E6 (X: 1873.3, Y: 2344.2)\nSubmitted By MrCrazy",
  "lat": 2344.2294642925262,
  "lng": 1873.3019434671655,
  "icon": "🗺️",
  "addedTime": 1776068207650,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```