### PR TITLE
New marker: treasure maps – Savage Divide Treasure Map #10 dig site: This treasure can be found east of the Bailey Family Cabin, near a small lake where two rusted vehicles stand near the water.

### DIFF
--- a/community-markers/marker-id-7d25de22-187f-4788-9ef7-7bcfc11f3f54.json
+++ b/community-markers/marker-id-7d25de22-187f-4788-9ef7-7bcfc11f3f54.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-7d25de22-187f-4788-9ef7-7bcfc11f3f54",
+  "cid": "treasure maps_savage_divide_treasure_map_10_dig_site_this_treasure_can_be_found_east_of_the_bailey_family_cabin_near_a_small_lake_where_two_rusted_vehicles_stand_near_the_water_grid_h9_x_31003_y_3297_3297.00000_3100.25000",
+  "category": "treasure maps",
+  "desc": "Savage Divide Treasure Map #10 dig site: This treasure can be found east of the Bailey Family Cabin, near a small lake where two rusted vehicles stand near the water.\nGrid H9 (X: 3100.3, Y: 3297)\nSubmitted By MrCrazy",
+  "lat": 3297,
+  "lng": 3100.25,
+  "icon": "🗺️",
+  "addedTime": 1777433621698,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-7d25de22-187f-4788-9ef7-7bcfc11f3f54",
  "cid": "treasure maps_savage_divide_treasure_map_10_dig_site_this_treasure_can_be_found_east_of_the_bailey_family_cabin_near_a_small_lake_where_two_rusted_vehicles_stand_near_the_water_grid_h9_x_31003_y_3297_3297.00000_3100.25000",
  "category": "treasure maps",
  "desc": "Savage Divide Treasure Map #10 dig site: This treasure can be found east of the Bailey Family Cabin, near a small lake where two rusted vehicles stand near the water.\nGrid H9 (X: 3100.3, Y: 3297)\nSubmitted By MrCrazy",
  "lat": 3297,
  "lng": 3100.25,
  "icon": "🗺️",
  "addedTime": 1777433621698,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```