### PR TITLE
New marker: treasure maps – Savage Divide Treasure Map #6 dig site: This treasure map can be found near the Palace of the Winding Path. North of it you will find the treasure in the steep wall, approximately at the point marked in the map.

### DIFF
--- a/community-markers/marker-id-389652c4-3284-482d-acfb-0b0a23a8a9b8.json
+++ b/community-markers/marker-id-389652c4-3284-482d-acfb-0b0a23a8a9b8.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-389652c4-3284-482d-acfb-0b0a23a8a9b8",
+  "cid": "treasure maps_savage_divide_treasure_map_10_dig_site_this_treasure_can_be_found_east_of_the_bailey_family_cabin_near_a_small_lake_where_two_rusted_vehicles_stand_near_the_water_grid_h9_x_31003_y_3297_3297.00000_3100.25000",
+  "category": "treasure maps",
+  "desc": "Savage Divide Treasure Map #6 dig site: This treasure map can be found near the Palace of the Winding Path. North of it you will find the treasure in the steep wall, approximately at the point marked in the map.\nGrid F9 (X: 2448.3, Y: 3290.3)\nSubmitted By MrCrazy",
+  "lat": 3290.25,
+  "lng": 2448.25,
+  "icon": "🗺️",
+  "addedTime": 1777434277003,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-389652c4-3284-482d-acfb-0b0a23a8a9b8",
  "cid": "treasure maps_savage_divide_treasure_map_10_dig_site_this_treasure_can_be_found_east_of_the_bailey_family_cabin_near_a_small_lake_where_two_rusted_vehicles_stand_near_the_water_grid_h9_x_31003_y_3297_3297.00000_3100.25000",
  "category": "treasure maps",
  "desc": "Savage Divide Treasure Map #6 dig site: This treasure map can be found near the Palace of the Winding Path. North of it you will find the treasure in the steep wall, approximately at the point marked in the map.\nGrid F9 (X: 2448.3, Y: 3290.3)\nSubmitted By MrCrazy",
  "lat": 3290.25,
  "lng": 2448.25,
  "icon": "🗺️",
  "addedTime": 1777434277003,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```