### PR TITLE
New marker: treasure maps – Savage Divide Treasure Map #6 dig site: This treasure map can be found near the Palace of the Winding Path. North of it you will find the treasure in the steep wall, approximately at the point marked in the map.

### DIFF
--- a/community-markers/marker-id-61a41ebc-e73e-4098-92ae-b6c53f2ee908.json
+++ b/community-markers/marker-id-61a41ebc-e73e-4098-92ae-b6c53f2ee908.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-61a41ebc-e73e-4098-92ae-b6c53f2ee908",
+  "cid": "treasure maps_savage_divide_treasure_map_6_dig_site_this_treasure_map_can_be_found_near_the_palace_of_the_winding_path_north_of_it_you_will_find_the_treasure_in_the_steep_wall_approximately_at_the_point_marked_in_the_map_grid_f9_x_24483_y_32903_3290.25000_2448.25000",
+  "category": "treasure maps",
+  "desc": "Savage Divide Treasure Map #6 dig site: This treasure map can be found near the Palace of the Winding Path. North of it you will find the treasure in the steep wall, approximately at the point marked in the map.\nGrid F9 (X: 2448, Y: 3290.9)\nSubmitted By MrCrazy",
+  "lat": 3290.875,
+  "lng": 2448,
+  "icon": "🗺️",
+  "addedTime": 1777443376394,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-61a41ebc-e73e-4098-92ae-b6c53f2ee908",
  "cid": "treasure maps_savage_divide_treasure_map_6_dig_site_this_treasure_map_can_be_found_near_the_palace_of_the_winding_path_north_of_it_you_will_find_the_treasure_in_the_steep_wall_approximately_at_the_point_marked_in_the_map_grid_f9_x_24483_y_32903_3290.25000_2448.25000",
  "category": "treasure maps",
  "desc": "Savage Divide Treasure Map #6 dig site: This treasure map can be found near the Palace of the Winding Path. North of it you will find the treasure in the steep wall, approximately at the point marked in the map.\nGrid F9 (X: 2448, Y: 3290.9)\nSubmitted By MrCrazy",
  "lat": 3290.875,
  "lng": 2448,
  "icon": "🗺️",
  "addedTime": 1777443376394,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```