### PR TITLE
New marker: treasure maps – Savage Divide Treasure Map #10 dig site: This treasure can be found east of the Bailey Family Cabin, near a small lake where two rusted vehicles stand near the water.

### DIFF
--- a/community-markers/marker-id-89da091a-e695-4165-986b-5238c92e94f0.json
+++ b/community-markers/marker-id-89da091a-e695-4165-986b-5238c92e94f0.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-89da091a-e695-4165-986b-5238c92e94f0",
+  "cid": "treasure maps_savage_divide_treasure_map_10_dig_site_this_treasure_can_be_found_east_of_the_bailey_family_cabin_near_a_small_lake_where_two_rusted_vehicles_stand_near_the_water_grid_h9_x_31003_y_3297_3297.00000_3100.25000",
+  "category": "treasure maps",
+  "desc": "Savage Divide Treasure Map #10 dig site: This treasure can be found east of the Bailey Family Cabin, near a small lake where two rusted vehicles stand near the water.\nGrid H9 (X: 3099.8, Y: 3296.7)\nSubmitted By MrCrazy",
+  "lat": 3296.71875,
+  "lng": 3099.78125,
+  "icon": "🗺️",
+  "addedTime": 1777443656128,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-89da091a-e695-4165-986b-5238c92e94f0",
  "cid": "treasure maps_savage_divide_treasure_map_10_dig_site_this_treasure_can_be_found_east_of_the_bailey_family_cabin_near_a_small_lake_where_two_rusted_vehicles_stand_near_the_water_grid_h9_x_31003_y_3297_3297.00000_3100.25000",
  "category": "treasure maps",
  "desc": "Savage Divide Treasure Map #10 dig site: This treasure can be found east of the Bailey Family Cabin, near a small lake where two rusted vehicles stand near the water.\nGrid H9 (X: 3099.8, Y: 3296.7)\nSubmitted By MrCrazy",
  "lat": 3296.71875,
  "lng": 3099.78125,
  "icon": "🗺️",
  "addedTime": 1777443656128,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```