### PR TITLE
New marker: treasure maps – Savage Divide Treasure Map #4 dig site: To find this treasure you go to Solomon’s Pond. There, a wooden bridge leads over a small lake. Cross the bridge, in the middle of the bridge, jump down near the rocks next to the bridge and walkway, edge of water. There you will find the mound with the treasure.

### DIFF
--- a/community-markers/marker-id-58b09582-959c-4cbd-a7cb-47797b842d86.json
+++ b/community-markers/marker-id-58b09582-959c-4cbd-a7cb-47797b842d86.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-58b09582-959c-4cbd-a7cb-47797b842d86",
+  "cid": "treasure maps_savage_divide_treasure_map_2_dig_site_go_to_the_train_station_and_then_walk_along_the_railway_tracks_to_the_north_look_for_a_red_and_blue_train_carriage_off_the_tracks_between_these_two_is_the_mound_the_top_of_the_world_tower_can_be_seen_from_here_grid_f5_x_2160_y_1932_1932.25439_2160.06882",
+  "category": "treasure maps",
+  "desc": "Savage Divide Treasure Map #4 dig site: To find this treasure you go to Solomon’s Pond. There, a wooden bridge leads over a small lake. Cross the bridge, in the middle of the bridge, jump down near the rocks next to the bridge and walkway, edge of water. There you will find the mound with the treasure.\nGrid F4 (X: 2303.3, Y: 1611.4)\nSubmitted By MrCrazy",
+  "lat": 1611.375,
+  "lng": 2303.25,
+  "icon": "🗺️",
+  "addedTime": 1777447903780,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-58b09582-959c-4cbd-a7cb-47797b842d86",
  "cid": "treasure maps_savage_divide_treasure_map_2_dig_site_go_to_the_train_station_and_then_walk_along_the_railway_tracks_to_the_north_look_for_a_red_and_blue_train_carriage_off_the_tracks_between_these_two_is_the_mound_the_top_of_the_world_tower_can_be_seen_from_here_grid_f5_x_2160_y_1932_1932.25439_2160.06882",
  "category": "treasure maps",
  "desc": "Savage Divide Treasure Map #4 dig site: To find this treasure you go to Solomon’s Pond. There, a wooden bridge leads over a small lake. Cross the bridge, in the middle of the bridge, jump down near the rocks next to the bridge and walkway, edge of water. There you will find the mound with the treasure.\nGrid F4 (X: 2303.3, Y: 1611.4)\nSubmitted By MrCrazy",
  "lat": 1611.375,
  "lng": 2303.25,
  "icon": "🗺️",
  "addedTime": 1777447903780,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```