### PR TITLE
New marker: treasure maps – Savage Divide Treasure Map #5 dig site: This treasure can be found on a promontory above the Blackwater Mine, east of the large lake in The Forest and the Whitespring Resort. Right in front of the big advertising sign is the pile of earth where you can dig for the treasure.

### DIFF
--- a/community-markers/marker-id-97eb1718-3034-47eb-a656-2aada3698f76.json
+++ b/community-markers/marker-id-97eb1718-3034-47eb-a656-2aada3698f76.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-97eb1718-3034-47eb-a656-2aada3698f76",
+  "cid": "treasure maps_savage_divide_treasure_map_4_dig_site_to_find_this_treasure_you_go_to_solomons_pond_there_a_wooden_bridge_leads_over_a_small_lake_cross_the_bridge_in_the_middle_of_the_bridge_jump_down_near_the_rocks_next_to_the_bridge_and_walkway_edge_of_water_there_you_will_find_the_mound_with_the_treasure_grid_f4_x_23033_y_16114_1611.37500_2303.25000",
+  "category": "treasure maps",
+  "desc": "Savage Divide Treasure Map #5 dig site: This treasure can be found on a promontory above the Blackwater Mine, east of the large lake in The Forest and the Whitespring Resort. Right in front of the big advertising sign is the pile of earth where you can dig for the treasure.\nGrid F5 (X: 2285.8, Y: 1714.5)\nSubmitted By MrCrazy",
+  "lat": 1714.5,
+  "lng": 2285.75,
+  "icon": "🗺️",
+  "addedTime": 1777448124508,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-97eb1718-3034-47eb-a656-2aada3698f76",
  "cid": "treasure maps_savage_divide_treasure_map_4_dig_site_to_find_this_treasure_you_go_to_solomons_pond_there_a_wooden_bridge_leads_over_a_small_lake_cross_the_bridge_in_the_middle_of_the_bridge_jump_down_near_the_rocks_next_to_the_bridge_and_walkway_edge_of_water_there_you_will_find_the_mound_with_the_treasure_grid_f4_x_23033_y_16114_1611.37500_2303.25000",
  "category": "treasure maps",
  "desc": "Savage Divide Treasure Map #5 dig site: This treasure can be found on a promontory above the Blackwater Mine, east of the large lake in The Forest and the Whitespring Resort. Right in front of the big advertising sign is the pile of earth where you can dig for the treasure.\nGrid F5 (X: 2285.8, Y: 1714.5)\nSubmitted By MrCrazy",
  "lat": 1714.5,
  "lng": 2285.75,
  "icon": "🗺️",
  "addedTime": 1777448124508,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```