### PR TITLE
New marker: treasure maps – Savage Divide Treasure Map #8 dig site: You can find this treasure at a rest stop near some tables, as shown on the map, a rusted motorcycle is leaning against a beam dig site near the wooden fence beams.

### DIFF
--- a/community-markers/marker-id-6516f6d3-5bbb-4232-976e-1225280152d9.json
+++ b/community-markers/marker-id-6516f6d3-5bbb-4232-976e-1225280152d9.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-6516f6d3-5bbb-4232-976e-1225280152d9",
+  "cid": "treasure maps_savage_divide_treasure_map_7_dig_site_this_treasure_can_be_found_in_the_mountains_south_of_savage_divide_east_of_the_spruce_knob_campground_the_pile_of_earth_is_on_a_rocky_outcrop_from_which_one_sees_the_two_metal_things_as_seen_on_the_treasure_map_grid_g3_x_2485_y_11683_1168.25000_2485.00000",
+  "category": "treasure maps",
+  "desc": "Savage Divide Treasure Map #8 dig site: You can find this treasure at a rest stop near some tables, as shown on the map, a rusted motorcycle is leaning against a beam dig site near the wooden fence beams.\nGrid G6 (X: 2524.8, Y: 2264.3)\nSubmitted By MrCrazy",
+  "lat": 2264.25,
+  "lng": 2524.75,
+  "icon": "🗺️",
+  "addedTime": 1777449187684,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-6516f6d3-5bbb-4232-976e-1225280152d9",
  "cid": "treasure maps_savage_divide_treasure_map_7_dig_site_this_treasure_can_be_found_in_the_mountains_south_of_savage_divide_east_of_the_spruce_knob_campground_the_pile_of_earth_is_on_a_rocky_outcrop_from_which_one_sees_the_two_metal_things_as_seen_on_the_treasure_map_grid_g3_x_2485_y_11683_1168.25000_2485.00000",
  "category": "treasure maps",
  "desc": "Savage Divide Treasure Map #8 dig site: You can find this treasure at a rest stop near some tables, as shown on the map, a rusted motorcycle is leaning against a beam dig site near the wooden fence beams.\nGrid G6 (X: 2524.8, Y: 2264.3)\nSubmitted By MrCrazy",
  "lat": 2264.25,
  "lng": 2524.75,
  "icon": "🗺️",
  "addedTime": 1777449187684,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```