### PR TITLE
New marker: treasure maps – Savage Divide Treasure Map #9 dig site: To find this treasure, you will need to travel to the Autumn Acre Cabin southeast of the ATLAS Observatory. Behind the cabin is a small forest. Run through it and you come to a rocky slope. If you look down, you can already see the mound with the treasure, at the point marked on the map.

### DIFF
--- a/community-markers/marker-id-7927f833-7f91-41f0-b213-02e9409d04fe.json
+++ b/community-markers/marker-id-7927f833-7f91-41f0-b213-02e9409d04fe.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-7927f833-7f91-41f0-b213-02e9409d04fe",
+  "cid": "treasure maps_savage_divide_treasure_map_8_dig_site_you_can_find_this_treasure_at_a_rest_stop_near_some_tables_as_shown_on_the_map_a_rusted_motorcycle_is_leaning_against_a_beam_dig_site_near_the_wooden_fence_beams_grid_g6_x_25248_y_22643_2264.25000_2524.75000",
+  "category": "treasure maps",
+  "desc": "Savage Divide Treasure Map #9 dig site: To find this treasure, you will need to travel to the Autumn Acre Cabin southeast of the ATLAS Observatory. Behind the cabin is a small forest. Run through it and you come to a rocky slope. If you look down, you can already see the mound with the treasure, at the point marked on the map.\nGrid G6 (X: 2748.5, Y: 2345.3)\nSubmitted By MrCrazy",
+  "lat": 2345.25,
+  "lng": 2748.5,
+  "icon": "🗺️",
+  "addedTime": 1777449979969,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-7927f833-7f91-41f0-b213-02e9409d04fe",
  "cid": "treasure maps_savage_divide_treasure_map_8_dig_site_you_can_find_this_treasure_at_a_rest_stop_near_some_tables_as_shown_on_the_map_a_rusted_motorcycle_is_leaning_against_a_beam_dig_site_near_the_wooden_fence_beams_grid_g6_x_25248_y_22643_2264.25000_2524.75000",
  "category": "treasure maps",
  "desc": "Savage Divide Treasure Map #9 dig site: To find this treasure, you will need to travel to the Autumn Acre Cabin southeast of the ATLAS Observatory. Behind the cabin is a small forest. Run through it and you come to a rocky slope. If you look down, you can already see the mound with the treasure, at the point marked on the map.\nGrid G6 (X: 2748.5, Y: 2345.3)\nSubmitted By MrCrazy",
  "lat": 2345.25,
  "lng": 2748.5,
  "icon": "🗺️",
  "addedTime": 1777449979969,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```