### PR TITLE
New marker: treasure maps – Toxic Valley Treasure Map #1 dig site: To find this treasure, you have to go to the Becker farm house. It is located northeast of Vault 76 in Toxic Valley. West of the farm house you will find a dilapidated house only a corner of the house remains, the dig site can be found next to the dilapidated house.

### DIFF
--- a/community-markers/marker-id-e4b73add-5aa9-4bf4-ab91-afe271f16111.json
+++ b/community-markers/marker-id-e4b73add-5aa9-4bf4-ab91-afe271f16111.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-e4b73add-5aa9-4bf4-ab91-afe271f16111",
+  "cid": "treasure maps_toxic_valley_treasure_map_1_dig_site_to_find_this_treasure_y_3106.68750_1504.62500_ar59h2sb",
+  "category": "treasure maps",
+  "desc": "Toxic Valley Treasure Map #1 dig site: To find this treasure, you have to go to the Becker farm house. It is located northeast of Vault 76 in Toxic Valley. West of the farm house you will find a dilapidated house only a corner of the house remains, the dig site can be found next to the dilapidated house.\nGrid D8 (X: 1504.6, Y: 3106.7)\nSubmitted By MrCrazy",
+  "lat": 3106.6875,
+  "lng": 1504.625,
+  "icon": "🗺️",
+  "addedTime": 1777520192621,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-e4b73add-5aa9-4bf4-ab91-afe271f16111",
  "cid": "treasure maps_toxic_valley_treasure_map_1_dig_site_to_find_this_treasure_y_3106.68750_1504.62500_ar59h2sb",
  "category": "treasure maps",
  "desc": "Toxic Valley Treasure Map #1 dig site: To find this treasure, you have to go to the Becker farm house. It is located northeast of Vault 76 in Toxic Valley. West of the farm house you will find a dilapidated house only a corner of the house remains, the dig site can be found next to the dilapidated house.\nGrid D8 (X: 1504.6, Y: 3106.7)\nSubmitted By MrCrazy",
  "lat": 3106.6875,
  "lng": 1504.625,
  "icon": "🗺️",
  "addedTime": 1777520192621,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```