### PR TITLE
New marker: treasure maps – Toxic Valley Treasure Map #2 dig site: The treasure from this treasure map can be found northeast of Grafton and west of Clarksburg on a hill by the water tower, from water tower head up hill south west a short walk to find the dig site.

### DIFF
--- a/community-markers/marker-id-973fa187-a059-493d-b31d-08d8a06d60fd.json
+++ b/community-markers/marker-id-973fa187-a059-493d-b31d-08d8a06d60fd.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-973fa187-a059-493d-b31d-08d8a06d60fd",
+  "cid": "treasure maps_toxic_valley_treasure_map_1_dig_site_to_find_this_treasure_y_3106.68750_1504.62500_a06d60fd",
+  "category": "treasure maps",
+  "desc": "Toxic Valley Treasure Map #2 dig site: The treasure from this treasure map can be found northeast of Grafton and west of Clarksburg on a hill by the water tower, from water tower head up hill south west a short walk to find the dig site.\nGrid E8 (X: 1834.1, Y: 3194)\nSubmitted By MrCrazy",
+  "lat": 3194,
+  "lng": 1834.125,
+  "icon": "🗺️",
+  "addedTime": 1777520684918,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-973fa187-a059-493d-b31d-08d8a06d60fd",
  "cid": "treasure maps_toxic_valley_treasure_map_1_dig_site_to_find_this_treasure_y_3106.68750_1504.62500_a06d60fd",
  "category": "treasure maps",
  "desc": "Toxic Valley Treasure Map #2 dig site: The treasure from this treasure map can be found northeast of Grafton and west of Clarksburg on a hill by the water tower, from water tower head up hill south west a short walk to find the dig site.\nGrid E8 (X: 1834.1, Y: 3194)\nSubmitted By MrCrazy",
  "lat": 3194,
  "lng": 1834.125,
  "icon": "🗺️",
  "addedTime": 1777520684918,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```