### PR TITLE
New marker: treasure maps – Toxic Valley Treasure Map #3 dig site: To find this treasure, head to Pioneer Scout Camp in the southwestern corner of Toxic Valley. From there, head southwest to the small island in the lake. On the island, where the sailboat is located, you will find the dig site.

### DIFF
--- a/community-markers/marker-id-674f18be-5e7a-452a-aacc-cbd7d8df7ee7.json
+++ b/community-markers/marker-id-674f18be-5e7a-452a-aacc-cbd7d8df7ee7.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-674f18be-5e7a-452a-aacc-cbd7d8df7ee7",
+  "cid": "treasure maps_toxic_valley_treasure_map_2_dig_site_the_treasure_from_this__3194.00000_1834.12500_d8df7ee7",
+  "category": "treasure maps",
+  "desc": "Toxic Valley Treasure Map #3 dig site: To find this treasure, head to Pioneer Scout Camp in the southwestern corner of Toxic Valley. From there, head southwest to the small island in the lake. On the island, where the sailboat is located, you will find the dig site.\nGrid F8 (X: 2089.1, Y: 2992.5)\nSubmitted By MrCrazy",
+  "lat": 2992.49753856821,
+  "lng": 2089.0996868452485,
+  "icon": "🗺️",
+  "addedTime": 1777521029477,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-674f18be-5e7a-452a-aacc-cbd7d8df7ee7",
  "cid": "treasure maps_toxic_valley_treasure_map_2_dig_site_the_treasure_from_this__3194.00000_1834.12500_d8df7ee7",
  "category": "treasure maps",
  "desc": "Toxic Valley Treasure Map #3 dig site: To find this treasure, head to Pioneer Scout Camp in the southwestern corner of Toxic Valley. From there, head southwest to the small island in the lake. On the island, where the sailboat is located, you will find the dig site.\nGrid F8 (X: 2089.1, Y: 2992.5)\nSubmitted By MrCrazy",
  "lat": 2992.49753856821,
  "lng": 2089.0996868452485,
  "icon": "🗺️",
  "addedTime": 1777521029477,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```