### PR TITLE
New marker: treasure maps – Ash Heap Treasure Map #1 dig site: To find this treasure, head to AMS Testing Site in the south of Ash Heap. From there, head north, using the big red crane as your orientation. Look for a large tunnel entrance that is closed with a grid. On the slope to the left you will find the mound with the treasure.

### DIFF
--- a/community-markers/marker-id-df6c1fbe-f00a-43ba-8410-e64c906ef21b.json
+++ b/community-markers/marker-id-df6c1fbe-f00a-43ba-8410-e64c906ef21b.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-df6c1fbe-f00a-43ba-8410-e64c906ef21b",
+  "cid": "treasure maps_ash_heap_treasure_map_1_dig_site_to_find_this_treasure_head__1038.12500_1158.75000_84mwfe2r",
+  "category": "treasure maps",
+  "desc": "Ash Heap Treasure Map #1 dig site: To find this treasure, head to AMS Testing Site in the south of Ash Heap. From there, head north, using the big red crane as your orientation. Look for a large tunnel entrance that is closed with a grid. On the slope to the left you will find the mound with the treasure.\nGrid C3 (X: 1158.8, Y: 1038.1)\nSubmitted By MrCrazy",
+  "lat": 1038.125,
+  "lng": 1158.75,
+  "icon": "🗺️",
+  "addedTime": 1777623406336,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-df6c1fbe-f00a-43ba-8410-e64c906ef21b",
  "cid": "treasure maps_ash_heap_treasure_map_1_dig_site_to_find_this_treasure_head__1038.12500_1158.75000_84mwfe2r",
  "category": "treasure maps",
  "desc": "Ash Heap Treasure Map #1 dig site: To find this treasure, head to AMS Testing Site in the south of Ash Heap. From there, head north, using the big red crane as your orientation. Look for a large tunnel entrance that is closed with a grid. On the slope to the left you will find the mound with the treasure.\nGrid C3 (X: 1158.8, Y: 1038.1)\nSubmitted By MrCrazy",
  "lat": 1038.125,
  "lng": 1158.75,
  "icon": "🗺️",
  "addedTime": 1777623406336,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```