### PR TITLE
New marker: treasure maps – Ash Heap Treasure Map #2 dig site: To recover this treasure, go to the place marked in the map. There you will find a few dilapidated cabins by a pond. Find the house next to a jeep. As marked on the treasure map, next to the jeep you will find the mound with the treasure.

### DIFF
--- a/community-markers/marker-id-a3fa1309-b805-4d7d-b218-e786d4d9b2ec.json
+++ b/community-markers/marker-id-a3fa1309-b805-4d7d-b218-e786d4d9b2ec.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-a3fa1309-b805-4d7d-b218-e786d4d9b2ec",
+  "cid": "treasure maps_ash_heap_treasure_map_2_dig_site_to_recover_this_treasure_go_1473.75000_1338.87500_6wgx1ovb",
+  "category": "treasure maps",
+  "desc": "Ash Heap Treasure Map #2 dig site: To recover this treasure, go to the place marked in the map. There you will find a few dilapidated cabins by a pond. Find the house next to a jeep. As marked on the treasure map, next to the jeep you will find the mound with the treasure.\nGrid D4 (X: 1338.9, Y: 1473.8)\nSubmitted By MrCrazy",
+  "lat": 1473.75,
+  "lng": 1338.875,
+  "icon": "🗺️",
+  "addedTime": 1777623647512,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-a3fa1309-b805-4d7d-b218-e786d4d9b2ec",
  "cid": "treasure maps_ash_heap_treasure_map_2_dig_site_to_recover_this_treasure_go_1473.75000_1338.87500_6wgx1ovb",
  "category": "treasure maps",
  "desc": "Ash Heap Treasure Map #2 dig site: To recover this treasure, go to the place marked in the map. There you will find a few dilapidated cabins by a pond. Find the house next to a jeep. As marked on the treasure map, next to the jeep you will find the mound with the treasure.\nGrid D4 (X: 1338.9, Y: 1473.8)\nSubmitted By MrCrazy",
  "lat": 1473.75,
  "lng": 1338.875,
  "icon": "🗺️",
  "addedTime": 1777623647512,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```