### PR TITLE
New marker: creatures – Spooky Scorched in the area if the event is running and also Scorched Wanderer, search in & around the Wavy Willards Water Park.

### DIFF
--- a/community-markers/marker-id-998d1d0c-c03d-4985-aae0-251a3e1c3844.json
+++ b/community-markers/marker-id-998d1d0c-c03d-4985-aae0-251a3e1c3844.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-998d1d0c-c03d-4985-aae0-251a3e1c3844",
+  "cid": "creatures_spooky_scorched_in_the_area_if_the_event_is_running_and_also_3419.25000_1806.75000_70rxacf9",
+  "category": "creatures",
+  "desc": "Spooky Scorched in the area if the event is running and also Scorched Wanderer, search in & around the Wavy Willards Water Park.\nGrid E9 (X: 1806.8, Y: 3419.3)\nSubmitted By MrCrazy",
+  "lat": 3419.25,
+  "lng": 1806.75,
+  "icon": "🐺",
+  "addedTime": 1777627431035,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-998d1d0c-c03d-4985-aae0-251a3e1c3844",
  "cid": "creatures_spooky_scorched_in_the_area_if_the_event_is_running_and_also_3419.25000_1806.75000_70rxacf9",
  "category": "creatures",
  "desc": "Spooky Scorched in the area if the event is running and also Scorched Wanderer, search in & around the Wavy Willards Water Park.\nGrid E9 (X: 1806.8, Y: 3419.3)\nSubmitted By MrCrazy",
  "lat": 3419.25,
  "lng": 1806.75,
  "icon": "🐺",
  "addedTime": 1777627431035,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```