### PR TITLE
New marker: aid – Addictol can sometimes be found in the fortune tellers camper van near the bounty board

### DIFF
--- a/community-markers/marker-id-7cc2da6d-d569-4a40-9767-99624574fa93.json
+++ b/community-markers/marker-id-7cc2da6d-d569-4a40-9767-99624574fa93.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-7cc2da6d-d569-4a40-9767-99624574fa93",
+  "cid": "aid_addictol_can_sometimes_be_found_in_the_fortune_tellers_campe_2745.75000_400.50000_h0d59ug5",
+  "category": "aid",
+  "desc": "Addictol can sometimes be found in the fortune tellers camper van near the bounty board\nGrid A7 (X: 400.5, Y: 2745.8)\nSubmitted By MrCrazy",
+  "lat": 2745.75,
+  "lng": 400.5,
+  "icon": "💉",
+  "addedTime": 1777628992422,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-7cc2da6d-d569-4a40-9767-99624574fa93",
  "cid": "aid_addictol_can_sometimes_be_found_in_the_fortune_tellers_campe_2745.75000_400.50000_h0d59ug5",
  "category": "aid",
  "desc": "Addictol can sometimes be found in the fortune tellers camper van near the bounty board\nGrid A7 (X: 400.5, Y: 2745.8)\nSubmitted By MrCrazy",
  "lat": 2745.75,
  "lng": 400.5,
  "icon": "💉",
  "addedTime": 1777628992422,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```