### PR TITLE
New marker: minerva – Minerva is located at The Whitespring Resort in the southeast of The Forest. She maintains a tent directly in front of the main entrance.

### DIFF
--- a/community-markers/marker-id-f611267f-41a5-4e77-ad68-d424af810900.json
+++ b/community-markers/marker-id-f611267f-41a5-4e77-ad68-d424af810900.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-f611267f-41a5-4e77-ad68-d424af810900",
+  "cid": "minerva_minerva_is_located_at_foundation_in_the_southern_savage_divi_1313.75000_2279.00000_af810900",
+  "category": "minerva",
+  "desc": "Minerva is located at The Whitespring Resort in the southeast of The Forest. She maintains a tent directly in front of the main entrance.\nMinerva rotates weekly among four locations. Check the the Nuke Codes & Minerva button in the tools panel.\nGrid F5 (X: 2107.5, Y: 1696.8)\nSubmitted By Anonymous Wastelander",
+  "lat": 1696.75,
+  "lng": 2107.5,
+  "icon": "🛒",
+  "addedTime": 1777898181249,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** Anonymous Wastelander

**Marker:**
```json
{
  "id": "id-f611267f-41a5-4e77-ad68-d424af810900",
  "cid": "minerva_minerva_is_located_at_foundation_in_the_southern_savage_divi_1313.75000_2279.00000_af810900",
  "category": "minerva",
  "desc": "Minerva is located at The Whitespring Resort in the southeast of The Forest. She maintains a tent directly in front of the main entrance.\nMinerva rotates weekly among four locations. Check the the Nuke Codes & Minerva button in the tools panel.\nGrid F5 (X: 2107.5, Y: 1696.8)\nSubmitted By Anonymous Wastelander",
  "lat": 1696.75,
  "lng": 2107.5,
  "icon": "🛒",
  "addedTime": 1777898181249,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```