### PR TITLE
New marker: minerva – Minerva is located at Fort Atlas in the center of the Savage Divide. Fast travel to Fort Atlas. When facing the main gates, she can be found on the right side next to the fort.

### DIFF
--- a/community-markers/marker-id-676c79d6-4453-4fdc-955b-afc6e4bbbfc6.json
+++ b/community-markers/marker-id-676c79d6-4453-4fdc-955b-afc6e4bbbfc6.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-676c79d6-4453-4fdc-955b-afc6e4bbbfc6",
+  "cid": "minerva_minerva_is_located_at_the_whitespring_resort_in_the_southeas_1696.75000_2107.50000_e4bbbfc6",
+  "category": "minerva",
+  "desc": "Minerva is located at Fort Atlas in the center of the Savage Divide. Fast travel to Fort Atlas. When facing the main gates, she can be found on the right side next to the fort.\nMinerva rotates weekly among four locations. Check the the Nuke Codes & Minerva button in the tools panel.\nGrid G7 (X: 2635.8, Y: 2545)\nSubmitted By Anonymous Wastelander",
+  "lat": 2545,
+  "lng": 2635.75,
+  "icon": "🛒",
+  "addedTime": 1777898270323,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** Anonymous Wastelander

**Marker:**
```json
{
  "id": "id-676c79d6-4453-4fdc-955b-afc6e4bbbfc6",
  "cid": "minerva_minerva_is_located_at_the_whitespring_resort_in_the_southeas_1696.75000_2107.50000_e4bbbfc6",
  "category": "minerva",
  "desc": "Minerva is located at Fort Atlas in the center of the Savage Divide. Fast travel to Fort Atlas. When facing the main gates, she can be found on the right side next to the fort.\nMinerva rotates weekly among four locations. Check the the Nuke Codes & Minerva button in the tools panel.\nGrid G7 (X: 2635.8, Y: 2545)\nSubmitted By Anonymous Wastelander",
  "lat": 2545,
  "lng": 2635.75,
  "icon": "🛒",
  "addedTime": 1777898270323,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```