### PR TITLE
New marker: minerva – Minerva is located at The Crater in the northern Toxic Valley. Fast travel to The Crater and proceed west, away from the crop fields, to reach her position.

### DIFF
--- a/community-markers/marker-id-70f93c03-a165-465d-b8c0-35dd56766faa.json
+++ b/community-markers/marker-id-70f93c03-a165-465d-b8c0-35dd56766faa.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-70f93c03-a165-465d-b8c0-35dd56766faa",
+  "cid": "minerva_minerva_is_located_at_fort_atlas_in_the_center_of_the_savage_2545.00000_2635.75000_56766faa",
+  "category": "minerva",
+  "desc": "Minerva is located at The Crater in the northern Toxic Valley. Fast travel to The Crater and proceed west, away from the crop fields, to reach her position.\nMinerva rotates weekly among four locations. Check the the Nuke Codes & Minerva button in the tools panel.\nGrid F9 (X: 2206.8, Y: 3442.5)\nSubmitted By Anonymous Wastelander",
+  "lat": 3442.5,
+  "lng": 2206.75,
+  "icon": "🛒",
+  "addedTime": 1777898297241,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** Anonymous Wastelander

**Marker:**
```json
{
  "id": "id-70f93c03-a165-465d-b8c0-35dd56766faa",
  "cid": "minerva_minerva_is_located_at_fort_atlas_in_the_center_of_the_savage_2545.00000_2635.75000_56766faa",
  "category": "minerva",
  "desc": "Minerva is located at The Crater in the northern Toxic Valley. Fast travel to The Crater and proceed west, away from the crop fields, to reach her position.\nMinerva rotates weekly among four locations. Check the the Nuke Codes & Minerva button in the tools panel.\nGrid F9 (X: 2206.8, Y: 3442.5)\nSubmitted By Anonymous Wastelander",
  "lat": 3442.5,
  "lng": 2206.75,
  "icon": "🛒",
  "addedTime": 1777898297241,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```