### PR TITLE
New marker: holotapes – Overseers journal - entry 6 near Mount Blair located in the Ash Heap on a stand outside a warehouse/shack east of Mount Blair (near Abandoned Mine Shaft 6.

### DIFF
--- a/community-markers/marker-id-90228b25-fa7a-4556-bf65-ecf4161829e9.json
+++ b/community-markers/marker-id-90228b25-fa7a-4556-bf65-ecf4161829e9.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-90228b25-fa7a-4556-bf65-ecf4161829e9",
+  "cid": "holotapes_overseers_journal_entry_6_near_mount_blair_located_in_the_as_1310.62170_1221.00000_vht23ikk",
+  "category": "holotapes",
+  "desc": "Overseers journal - entry 6 near Mount Blair located in the Ash Heap on a stand outside a warehouse/shack east of Mount Blair (near Abandoned Mine Shaft 6.\nGrid C4 (X: 1221, Y: 1310.6)\nSubmitted By MrCrazy",
+  "lat": 1310.6216998191683,
+  "lng": 1221,
+  "icon": "📀",
+  "addedTime": 1778764969542,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-90228b25-fa7a-4556-bf65-ecf4161829e9",
  "cid": "holotapes_overseers_journal_entry_6_near_mount_blair_located_in_the_as_1310.62170_1221.00000_vht23ikk",
  "category": "holotapes",
  "desc": "Overseers journal - entry 6 near Mount Blair located in the Ash Heap on a stand outside a warehouse/shack east of Mount Blair (near Abandoned Mine Shaft 6.\nGrid C4 (X: 1221, Y: 1310.6)\nSubmitted By MrCrazy",
  "lat": 1310.6216998191683,
  "lng": 1221,
  "icon": "📀",
  "addedTime": 1778764969542,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```