### PR TITLE
New marker: holotapes – Overseers log – #2 This log can be found in the church used by the Responders in Flatwoods. It will be on the right-hand side of the entrance.

### DIFF
--- a/community-markers/marker-id-cab13a55-910d-4e19-8ff0-61b571165a50.json
+++ b/community-markers/marker-id-cab13a55-910d-4e19-8ff0-61b571165a50.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-cab13a55-910d-4e19-8ff0-61b571165a50",
+  "cid": "holotapes_overseers_log_2_this_log_can_be_found_in_the_church_used_by__2191.00496_1302.12500_qggsf29i",
+  "category": "holotapes",
+  "desc": "Overseers log – #2 This log can be found in the church used by the Responders in Flatwoods. It will be on the right-hand side of the entrance.\nGrid D6 (X: 1302.1, Y: 2191)\nSubmitted By MrCrazy",
+  "lat": 2191.0049638336345,
+  "lng": 1302.125,
+  "icon": "📀",
+  "addedTime": 1778921094088,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-cab13a55-910d-4e19-8ff0-61b571165a50",
  "cid": "holotapes_overseers_log_2_this_log_can_be_found_in_the_church_used_by__2191.00496_1302.12500_qggsf29i",
  "category": "holotapes",
  "desc": "Overseers log – #2 This log can be found in the church used by the Responders in Flatwoods. It will be on the right-hand side of the entrance.\nGrid D6 (X: 1302.1, Y: 2191)\nSubmitted By MrCrazy",
  "lat": 2191.0049638336345,
  "lng": 1302.125,
  "icon": "📀",
  "addedTime": 1778921094088,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```