### PR TITLE
New marker: holotapes – Overseers log – #3 Find this log on the second floor of the Morgantown Airport. Go to the basement first and collect the keycard from the hand of Responder corpse. This will allow you to go to the second floor. Find the Command Post door.

### DIFF
--- a/community-markers/marker-id-7f29c693-376c-440b-9746-696804c172f5.json
+++ b/community-markers/marker-id-7f29c693-376c-440b-9746-696804c172f5.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-7f29c693-376c-440b-9746-696804c172f5",
+  "cid": "holotapes_overseers_log_3_find_this_log_on_the_second_floor_of_the_mor_2767.49746_1946.75000_i518ct78",
+  "category": "holotapes",
+  "desc": "Overseers log – #3 Find this log on the second floor of the Morgantown Airport. Go to the basement first and collect the keycard from the hand of Responder corpse. This will allow you to go to the second floor. Find the Command Post door.\nGrid E7 (X: 1908, Y: 2747.6)\nSubmitted By MrCrazy",
+  "lat": 2747.6255696202534,
+  "lng": 1908,
+  "icon": "📀",
+  "addedTime": 1778922318385,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-7f29c693-376c-440b-9746-696804c172f5",
  "cid": "holotapes_overseers_log_3_find_this_log_on_the_second_floor_of_the_mor_2767.49746_1946.75000_i518ct78",
  "category": "holotapes",
  "desc": "Overseers log – #3 Find this log on the second floor of the Morgantown Airport. Go to the basement first and collect the keycard from the hand of Responder corpse. This will allow you to go to the second floor. Find the Command Post door.\nGrid E7 (X: 1908, Y: 2747.6)\nSubmitted By MrCrazy",
  "lat": 2747.6255696202534,
  "lng": 1908,
  "icon": "📀",
  "addedTime": 1778922318385,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```