### PR TITLE
New marker: holotapes – Overseers log – #7 The log is inside Camp Venture in the Mire region of the map. You will need to get past a terminal to enter the area or pick the lock. The password is in the basement of one of the smaller buildings outside of the main camp. Find a small note showing Command Center Password in the basement.

### DIFF
--- a/community-markers/marker-id-ea838552-321a-4c53-8dca-59edf7e18f48.json
+++ b/community-markers/marker-id-ea838552-321a-4c53-8dca-59edf7e18f48.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-ea838552-321a-4c53-8dca-59edf7e18f48",
+  "cid": "holotapes_overseers_log_7_the_log_is_inside_camp_venture_in_the_mire_r_1763.49705_3170.37500_rsg9th52",
+  "category": "holotapes",
+  "desc": "Overseers log – #7 The log is inside Camp Venture in the Mire region of the map. You will need to get past a terminal to enter the area or pick the lock. The password is in the basement of one of the smaller buildings outside of the main camp. Find a small note showing Command Center Password in the basement.\nGrid H5 (X: 3163.8, Y: 1772.6)\nSubmitted By MrCrazy",
+  "lat": 1772.6454067002796,
+  "lng": 3163.75,
+  "icon": "📀",
+  "addedTime": 1778928784334,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-ea838552-321a-4c53-8dca-59edf7e18f48",
  "cid": "holotapes_overseers_log_7_the_log_is_inside_camp_venture_in_the_mire_r_1763.49705_3170.37500_rsg9th52",
  "category": "holotapes",
  "desc": "Overseers log – #7 The log is inside Camp Venture in the Mire region of the map. You will need to get past a terminal to enter the area or pick the lock. The password is in the basement of one of the smaller buildings outside of the main camp. Find a small note showing Command Center Password in the basement.\nGrid H5 (X: 3163.8, Y: 1772.6)\nSubmitted By MrCrazy",
  "lat": 1772.6454067002796,
  "lng": 3163.75,
  "icon": "📀",
  "addedTime": 1778928784334,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```