### PR TITLE
New marker: holotapes – Overseers log – #8 Located on the third floor of Fort Defiance and is one of two logs to be found in this location. You will need access to the elevator to find the log, and to do this, you must complete the quest 'Recruitment Blues'.

### DIFF
--- a/community-markers/marker-id-5827ba6f-1948-46fa-aaab-6ff7b46adc90.json
+++ b/community-markers/marker-id-5827ba6f-1948-46fa-aaab-6ff7b46adc90.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-5827ba6f-1948-46fa-aaab-6ff7b46adc90",
+  "cid": "holotapes_overseers_log_8_the_log_of_this_area_is_located_on_the_third_1114.18007_2791.65942_fjlul9rl",
+  "category": "holotapes",
+  "desc": "Overseers log – #8 Located on the third floor of Fort Defiance and is one of two logs to be found in this location. You will need access to the elevator to find the log, and to do this, you must complete the quest 'Recruitment Blues'.\nGrid G3 (X: 2787.4, Y: 1113.9)\nSubmitted By MrCrazy",
+  "lat": 1113.9369620253165,
+  "lng": 2787.375,
+  "icon": "📀",
+  "addedTime": 1778928871320,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-5827ba6f-1948-46fa-aaab-6ff7b46adc90",
  "cid": "holotapes_overseers_log_8_the_log_of_this_area_is_located_on_the_third_1114.18007_2791.65942_fjlul9rl",
  "category": "holotapes",
  "desc": "Overseers log – #8 Located on the third floor of Fort Defiance and is one of two logs to be found in this location. You will need access to the elevator to find the log, and to do this, you must complete the quest 'Recruitment Blues'.\nGrid G3 (X: 2787.4, Y: 1113.9)\nSubmitted By MrCrazy",
  "lat": 1113.9369620253165,
  "lng": 2787.375,
  "icon": "📀",
  "addedTime": 1778928871320,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```