### PR TITLE
New marker: holotapes – Overseers log – #9 The easiest way to find this log is to follow the Recruitment Blues quest. The log itself is located in the main building of Camp McClintock on the left as you enter the building, Camp McClintock sits next to the lake in the Forest region of the map.

### DIFF
--- a/community-markers/marker-id-82c4b095-4ded-4e1a-b3f3-d6849056258f.json
+++ b/community-markers/marker-id-82c4b095-4ded-4e1a-b3f3-d6849056258f.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-82c4b095-4ded-4e1a-b3f3-d6849056258f",
+  "cid": "holotapes_overseers_log_9_the_easiest_way_to_find_this_log_is_to_follo_1956.80651_1556.43750_73oyssza",
+  "category": "holotapes",
+  "desc": "Overseers log – #9 The easiest way to find this log is to follow the Recruitment Blues quest. The log itself is located in the main building of Camp McClintock on the left as you enter the building, Camp McClintock sits next to the lake in the Forest region of the map.\nGrid D5 (X: 1560.5, Y: 1967.1)\nSubmitted By MrCrazy",
+  "lat": 1967.0545293794355,
+  "lng": 1560.5,
+  "icon": "📀",
+  "addedTime": 1778929104824,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-82c4b095-4ded-4e1a-b3f3-d6849056258f",
  "cid": "holotapes_overseers_log_9_the_easiest_way_to_find_this_log_is_to_follo_1956.80651_1556.43750_73oyssza",
  "category": "holotapes",
  "desc": "Overseers log – #9 The easiest way to find this log is to follow the Recruitment Blues quest. The log itself is located in the main building of Camp McClintock on the left as you enter the building, Camp McClintock sits next to the lake in the Forest region of the map.\nGrid D5 (X: 1560.5, Y: 1967.1)\nSubmitted By MrCrazy",
  "lat": 1967.0545293794355,
  "lng": 1560.5,
  "icon": "📀",
  "addedTime": 1778929104824,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```