### PR TITLE
New marker: holotapes – Overseers log – #10 This log is located in the DMV section of the Charleston Capitol Building, which is to the east. The area is also used in the Recruitment Blues quest and will be on the left as you enter the DMV building area.

### DIFF
--- a/community-markers/marker-id-4894c364-c106-4f66-85b7-01b149721ead.json
+++ b/community-markers/marker-id-4894c364-c106-4f66-85b7-01b149721ead.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-4894c364-c106-4f66-85b7-01b149721ead",
+  "cid": "holotapes_overseers_log_10_this_log_is_located_in_the_dmv_section_of_t_1603.93193_1476.93750_p0jiaya2",
+  "category": "holotapes",
+  "desc": "Overseers log – #10 This log is located in the DMV section of the Charleston Capitol Building, which is to the east. The area is also used in the Recruitment Blues quest and will be on the left as you enter the DMV building area.\nGrid D5 (X: 1407.9, Y: 1645.9)\nSubmitted By MrCrazy",
+  "lat": 1645.921897775335,
+  "lng": 1407.875,
+  "icon": "📀",
+  "addedTime": 1778930594036,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-4894c364-c106-4f66-85b7-01b149721ead",
  "cid": "holotapes_overseers_log_10_this_log_is_located_in_the_dmv_section_of_t_1603.93193_1476.93750_p0jiaya2",
  "category": "holotapes",
  "desc": "Overseers log – #10 This log is located in the DMV section of the Charleston Capitol Building, which is to the east. The area is also used in the Recruitment Blues quest and will be on the left as you enter the DMV building area.\nGrid D5 (X: 1407.9, Y: 1645.9)\nSubmitted By MrCrazy",
  "lat": 1645.921897775335,
  "lng": 1407.875,
  "icon": "📀",
  "addedTime": 1778930594036,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```