### PR TITLE
New marker: holotapes – Overseers log – #11 After completing the Recruitment Blues quest, you will receive an ID Card, which will give you access to the fourth floor of Fort Defiance, allowing you to find the second log in this area. It will be in front of the elevator doors when you arrive on the fourth floor.

### DIFF
--- a/community-markers/marker-id-9370ea46-d67c-4694-9ca6-1d7ae460720d.json
+++ b/community-markers/marker-id-9370ea46-d67c-4694-9ca6-1d7ae460720d.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-9370ea46-d67c-4694-9ca6-1d7ae460720d",
+  "cid": "holotapes_overseers_log_11_after_completing_the_recruitment_blues_ques_1120.68699_2794.34375_hw0609k5",
+  "category": "holotapes",
+  "desc": "Overseers log – #11 After completing the Recruitment Blues quest, you will receive an ID Card, which will give you access to the fourth floor of Fort Defiance, allowing you to find the second log in this area. It will be in front of the elevator doors when you arrive on the fourth floor.\nGrid G3 (X: 2801.9, Y: 1120.7)\nSubmitted By MrCrazy",
+  "lat": 1120.655745931284,
+  "lng": 2801.9375,
+  "icon": "📀",
+  "addedTime": 1778930777384,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-9370ea46-d67c-4694-9ca6-1d7ae460720d",
  "cid": "holotapes_overseers_log_11_after_completing_the_recruitment_blues_ques_1120.68699_2794.34375_hw0609k5",
  "category": "holotapes",
  "desc": "Overseers log – #11 After completing the Recruitment Blues quest, you will receive an ID Card, which will give you access to the fourth floor of Fort Defiance, allowing you to find the second log in this area. It will be in front of the elevator doors when you arrive on the fourth floor.\nGrid G3 (X: 2801.9, Y: 1120.7)\nSubmitted By MrCrazy",
  "lat": 1120.655745931284,
  "lng": 2801.9375,
  "icon": "📀",
  "addedTime": 1778930777384,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```