### PR TITLE
New marker: holotapes – Overseers log – #12 The log will be in Grafton, which is in the Toxic Valley region of the map, and can be found next to the red AI Grafton Mayor. You may have found this log earlier if you followed the Grafton series of quests. The Mayor will be in their office at the intersection of the Trading Post and Voting Building.

### DIFF
--- a/community-markers/marker-id-6e3abd11-3657-4012-8434-3bb9d0056231.json
+++ b/community-markers/marker-id-6e3abd11-3657-4012-8434-3bb9d0056231.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-6e3abd11-3657-4012-8434-3bb9d0056231",
+  "cid": "holotapes_overseers_log_12_the_log_will_be_in_grafton_which_is_in_the__3046.48824_1696.37500_5zpjjhob",
+  "category": "holotapes",
+  "desc": "Overseers log – #12 The log will be in Grafton, which is in the Toxic Valley region of the map, and can be found next to the red AI Grafton Mayor. You may have found this log earlier if you followed the Grafton series of quests. The Mayor will be in their office at the intersection of the Trading Post and Voting Building.\nGrid E8 (X: 1703.4, Y: 3110.2)\nSubmitted By MrCrazy",
+  "lat": 3110.178943941313,
+  "lng": 1703.375,
+  "icon": "📀",
+  "addedTime": 1778930974165,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-6e3abd11-3657-4012-8434-3bb9d0056231",
  "cid": "holotapes_overseers_log_12_the_log_will_be_in_grafton_which_is_in_the__3046.48824_1696.37500_5zpjjhob",
  "category": "holotapes",
  "desc": "Overseers log – #12 The log will be in Grafton, which is in the Toxic Valley region of the map, and can be found next to the red AI Grafton Mayor. You may have found this log earlier if you followed the Grafton series of quests. The Mayor will be in their office at the intersection of the Trading Post and Voting Building.\nGrid E8 (X: 1703.4, Y: 3110.2)\nSubmitted By MrCrazy",
  "lat": 3110.178943941313,
  "lng": 1703.375,
  "icon": "📀",
  "addedTime": 1778930974165,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```