### PR TITLE
New marker: holotapes – Overseers log – #13 This log is found in a small shack where you can find the elevator to the Site Alpha Silo. It is north of the Radio Array, east of the BBQ Shack, and west of the Sugar Grove intelligence facility.

### DIFF
--- a/community-markers/marker-id-042ce123-1ed9-490f-9d71-2c3c031f0bbd.json
+++ b/community-markers/marker-id-042ce123-1ed9-490f-9d71-2c3c031f0bbd.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-042ce123-1ed9-490f-9d71-2c3c031f0bbd",
+  "cid": "holotapes_overseers_log_13_this_log_is_found_in_a_small_shack_where_yo_1942.49680_2602.81250_dsbi65ww",
+  "category": "holotapes",
+  "desc": "Overseers log – #13 This log is found in a small shack where you can find the elevator to the Site Alpha Silo. It is north of the Radio Array, east of the BBQ Shack, and west of the Sugar Grove intelligence facility.\nGrid G5 (X: 2602.8, Y: 1942.5)\nSubmitted By MrCrazy",
+  "lat": 1942.4967992766726,
+  "lng": 2602.8125,
+  "icon": "📀",
+  "addedTime": 1778931343809,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-042ce123-1ed9-490f-9d71-2c3c031f0bbd",
  "cid": "holotapes_overseers_log_13_this_log_is_found_in_a_small_shack_where_yo_1942.49680_2602.81250_dsbi65ww",
  "category": "holotapes",
  "desc": "Overseers log – #13 This log is found in a small shack where you can find the elevator to the Site Alpha Silo. It is north of the Radio Array, east of the BBQ Shack, and west of the Sugar Grove intelligence facility.\nGrid G5 (X: 2602.8, Y: 1942.5)\nSubmitted By MrCrazy",
  "lat": 1942.4967992766726,
  "lng": 2602.8125,
  "icon": "📀",
  "addedTime": 1778931343809,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```