### PR TITLE
New marker: holotapes – Overseers log – #14 This log will be near the Site Bravo elevator, south of the Palace of the Winding Path, and west of the Monongah Power Substation, which is east of the Grafton Mayor.

### DIFF
--- a/community-markers/marker-id-efac2c7d-e051-4ece-84df-2f733793736c.json
+++ b/community-markers/marker-id-efac2c7d-e051-4ece-84df-2f733793736c.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-efac2c7d-e051-4ece-84df-2f733793736c",
+  "cid": "holotapes_overseers_log_14_this_log_will_be_near_the_site_bravo_elevat_3008.93509_2338.12500_2eevc0rn",
+  "category": "holotapes",
+  "desc": "Overseers log – #14 This log will be near the Site Bravo elevator, south of the Palace of the Winding Path, and west of the Monongah Power Substation, which is east of the Grafton Mayor.\nGrid F8 (X: 2338.1, Y: 3008.9)\nSubmitted By MrCrazy",
+  "lat": 3008.9350858951175,
+  "lng": 2338.125,
+  "icon": "📀",
+  "addedTime": 1778931361598,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-efac2c7d-e051-4ece-84df-2f733793736c",
  "cid": "holotapes_overseers_log_14_this_log_will_be_near_the_site_bravo_elevat_3008.93509_2338.12500_2eevc0rn",
  "category": "holotapes",
  "desc": "Overseers log – #14 This log will be near the Site Bravo elevator, south of the Palace of the Winding Path, and west of the Monongah Power Substation, which is east of the Grafton Mayor.\nGrid F8 (X: 2338.1, Y: 3008.9)\nSubmitted By MrCrazy",
  "lat": 3008.9350858951175,
  "lng": 2338.125,
  "icon": "📀",
  "addedTime": 1778931361598,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```