### PR TITLE
New marker: holotapes – Overseers log – #16 This is a bit different from the other logs and requires you to visit Site Alpha after a nuke has been launched. If a nuke hasn't been triggered, then it won't appear, and you have to retrieve it while the nuke's effects are still active. It will be on a metal shelf across from the elevator.

### DIFF
--- a/community-markers/marker-id-ec2975c4-df2d-479b-b672-7542b2f7e554.json
+++ b/community-markers/marker-id-ec2975c4-df2d-479b-b672-7542b2f7e554.json
@@ -1,0 +1,18 @@
+{
+  "id": "id-ec2975c4-df2d-479b-b672-7542b2f7e554",
+  "cid": "holotapes_overseers_log_16_this_is_a_bit_different_from_the_other_logs_1935.86916_2612.68750_s4jq83ia",
+  "category": "holotapes",
+  "desc": "Overseers log – #16 This is a bit different from the other logs and requires you to visit Site Alpha after a nuke has been launched. If a nuke hasn't been triggered, then it won't appear, and you have to retrieve it while the nuke's effects are still active. It will be on a metal shelf across from the elevator.\nGrid G5 (X: 2612.7, Y: 1935.9)\nSubmitted By MrCrazy",
+  "lat": 1935.869159132007,
+  "lng": 2612.6875,
+  "icon": "📀",
+  "addedTime": 1778931428371,
+  "locked": true,
+  "isPostcard": false,
+  "isTemp": false,
+  "startTime": null,
+  "keepBtnBound": false,
+  "userEdited": false,
+  "wasCommunityKept": false,
+  "isCommunity": true
+}


### PR DESCRIPTION
**Submitted by:** MrCrazy

**Marker:**
```json
{
  "id": "id-ec2975c4-df2d-479b-b672-7542b2f7e554",
  "cid": "holotapes_overseers_log_16_this_is_a_bit_different_from_the_other_logs_1935.86916_2612.68750_s4jq83ia",
  "category": "holotapes",
  "desc": "Overseers log – #16 This is a bit different from the other logs and requires you to visit Site Alpha after a nuke has been launched. If a nuke hasn't been triggered, then it won't appear, and you have to retrieve it while the nuke's effects are still active. It will be on a metal shelf across from the elevator.\nGrid G5 (X: 2612.7, Y: 1935.9)\nSubmitted By MrCrazy",
  "lat": 1935.869159132007,
  "lng": 2612.6875,
  "icon": "📀",
  "addedTime": 1778931428371,
  "locked": true,
  "isPostcard": false,
  "isTemp": false,
  "startTime": null,
  "keepBtnBound": false,
  "userEdited": false,
  "wasCommunityKept": false,
  "isCommunity": true
}
```